### PR TITLE
Usage of sequelize Symbol operators

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -35,7 +35,6 @@ List.prototype._safeishParse = function(value, type, sequelize) {
   }
 };
 
-var stringOperators = /like|iLike|notLike|notILike/;
 List.prototype.fetch = function(req, res, context) {
   var self = this,
       model = this.model,
@@ -47,6 +46,10 @@ List.prototype.fetch = function(req, res, context) {
       defaultCount = 100,
       count = +context.count || +req.query.count || defaultCount,
       offset = +context.offset || +req.query.offset || 0;
+
+  var stringOperators = [
+    Sequelize.Op.like, Sequelize.Op.iLike, Sequelize.Op.notLike, Sequelize.Op.notILike,
+  ];
 
   // only look up attributes we care about
   options.attributes = options.attributes || this.resource.attributes;
@@ -72,11 +75,11 @@ List.prototype.fetch = function(req, res, context) {
     var searchParam = searchData.param;
     if (_.has(req.query, searchParam)) {
       var search = [];
-      var searchOperator = searchData.operator || '$like';
+      var searchOperator = searchData.operator || Sequelize.Op.like;
       var searchAttributes =
         searchData.attributes || getKeys(model.rawAttributes);
       searchAttributes.forEach(function(attr) {
-        if(stringOperators.test(searchOperator)){
+        if(stringOperators.indexOf(searchOperator) !== -1){
           var attrType = model.rawAttributes[attr].type;
           if (!(attrType instanceof Sequelize.STRING) &&
               !(attrType instanceof Sequelize.TEXT)) {
@@ -90,7 +93,7 @@ List.prototype.fetch = function(req, res, context) {
         var item = {};
         var query = {};
         var searchString;
-        if (!~searchOperator.toLowerCase().indexOf('like')) {
+        if (searchOperator !== Sequelize.Op.like) {
           searchString = req.query[searchParam];
         } else {
           searchString = '%' + req.query[searchParam] + '%';


### PR DESCRIPTION
https://github.com/GabeAtWork/epilogue/blob/fix_search/lib/Controllers/list.js#L106
`Sequelize.or.apply(null, search)` would not work without the new sequelize Symbol operators

I changed the expected operators to the official symbol ones.

fingers crossed for your merge in the base repo

Cheers